### PR TITLE
Fix license in package metadata

### DIFF
--- a/.nfpm.yaml
+++ b/.nfpm.yaml
@@ -10,7 +10,7 @@ maintainer: "Miek Gieben <miek@miek.nl>"
 description: |
   Utilities useful with CoreDNS.
 homepage: "https://github.com/coredns/coredns-utils"
-license: "MIT"
+license: "Apache-2.0"
 bindir: "/usr/sbin"
 files:
   coredns-keygen/coredns-keygen: "/usr/sbin/coredns-keygen"


### PR DESCRIPTION
In the package metadata, this corrects the license from MIT
to Apache-2.0 (to mirror what's in the LICENSE file).

Signed-off-by: Steve Winslow <swinslow@gmail.com>