### PR TITLE
Generate a DS record as well

### DIFF
--- a/coredns-keygen/README.md
+++ b/coredns-keygen/README.md
@@ -19,10 +19,11 @@ coredns-keygen ZONES...
 
 For each key pair the following files are created:
 
-* `K<zone>.+<algorithm>+<keytag>.key` for the DNSKEY RR, and
+* `K<zone>.+<algorithm>+<keytag>.key` for the DNSKEY RR,
+* `K<zone>.+<algorithm>+<keytag>.ds` for the DS RR, and,
 * `K<zone>.+<algorithm>+<keytag>.private` for the private one.
 
-For each generate key the base name of these file is printed to standard output once.
+For each generated key the base name of these file is printed to standard output once.
 
 ## Examples
 
@@ -36,5 +37,7 @@ Kexample.net.+013+00440
 
 ## Also See
 
-dnssec-keygen(8) can also used to generate keys and supports more options. See RFC 4033, 4034, 4035
-for the whole DNSSEC specification.
+dnssec-keygen(8) can also used to generate keys and supports more options. ldns-keygen(1) and
+ldns-key2ds(1) or similar utilities.
+
+See RFC 4033, 4034, 4035 for the DNSSEC specification.

--- a/coredns-keygen/main.go
+++ b/coredns-keygen/main.go
@@ -34,11 +34,16 @@ func main() {
 			log.Fatal(err)
 		}
 
+		ds := key.ToDS(dns.SHA256)
+
 		base := fmt.Sprintf("K%s+%03d+%05d", key.Header().Name, key.Algorithm, key.KeyTag())
 		if err := ioutil.WriteFile(base+".key", []byte(key.String()+"\n"), 0644); err != nil {
 			log.Fatal(err)
 		}
 		if err := ioutil.WriteFile(base+".private", []byte(key.PrivateKeyString(priv)), 0600); err != nil {
+			log.Fatal(err)
+		}
+		if err := ioutil.WriteFile(base+".ds", []byte(ds.String()+"\n"), 0644); err != nil {
 			log.Fatal(err)
 		}
 		fmt.Println(base) // output keys generated to stdout to mimic dnssec-keygen


### PR DESCRIPTION
Just generate a DS record, so we don't need to reach for ldns-key2ds for
just this part.